### PR TITLE
build: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,18 +341,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ alloc = []
 safe = []
 
 [dependencies]
-thiserror = { version = "2.0.11", optional = true }
+thiserror = { version = "2.0.18", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use alloc::{borrow::Cow, string::String, vec::Vec};
 /// assert_eq!(encoded, "`00`FF");
 /// ```
 #[cfg(feature = "alloc")]
-pub fn encode(input: &[u8]) -> Cow<str> {
+pub fn encode(input: &[u8]) -> Cow<'_, str> {
     // Get the first index that needs to be escaped
     let escape_index = input.iter().position(|byte| requires_escape(*byte));
 
@@ -91,7 +91,7 @@ where
 /// assert_eq!(decoded, [0x00, 0xFF].as_slice());
 /// ```
 #[cfg(feature = "alloc")]
-pub fn decode(input: &[u8]) -> Result<Cow<[u8]>, DecodeError> {
+pub fn decode(input: &[u8]) -> Result<Cow<'_, [u8]>, DecodeError> {
     // Get the first index that isn't already a valid unescaped byte
     let escape_index = input.iter().position(|byte| requires_escape(*byte));
 


### PR DESCRIPTION
Same as in https://github.com/kylewlacy/tick-encoding/pull/6, to use newer dependencies without impacting MSRV.