### PR TITLE
test: add new benchmark tests for upcoming modification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,11 @@ harness = false
 [[bench]]
 name = "encode"
 harness = false
+
+[[bench]]
+name = "iter"
+harness = false
+
+[[bench]]
+name = "functions"
+harness = false

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -92,7 +92,7 @@ fn decode_short_ascii(bencher: divan::Bencher, len: usize) {
 
 #[divan::bench(args = [16, 64, 256, 1024, 4096])]
 fn decode_short_binary(bencher: divan::Bencher, len: usize) {
-    let original = vec![0x00u8; len];
+    let original = vec![0x00; len];
     let encoded = tick_encoding::encode(&original);
 
     bencher.bench_local(|| {

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -2,6 +2,7 @@ fn main() {
     divan::main();
 }
 
+/// 100% ASCII - best case (no escaping needed)
 #[divan::bench]
 fn decode_unescaped(bencher: divan::Bencher) {
     let bytes = vec![b'a'; 1_000_000];
@@ -13,6 +14,7 @@ fn decode_unescaped(bencher: divan::Bencher) {
     });
 }
 
+/// 100% tick characters
 #[divan::bench]
 fn decode_ticks(bencher: divan::Bencher) {
     let bytes = vec![b'`'; 1_000_000];
@@ -24,10 +26,74 @@ fn decode_ticks(bencher: divan::Bencher) {
     });
 }
 
+/// 100% binary - worst case (all bytes need escaping)
 #[divan::bench]
 fn decode_binary(bencher: divan::Bencher) {
     let bytes = vec![0x00; 1_000_000];
     let encoded = tick_encoding::encode(&bytes);
+
+    bencher.bench_local(|| {
+        let decoded = tick_encoding::decode(divan::black_box(encoded.as_bytes())).unwrap();
+        divan::black_box(decoded);
+    });
+}
+
+/// 90% ASCII, 10% binary - mostly text content
+#[divan::bench]
+fn decode_mixed_90_10(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+
+    bencher.bench_local(|| {
+        let decoded = tick_encoding::decode(divan::black_box(encoded.as_bytes())).unwrap();
+        divan::black_box(decoded);
+    });
+}
+
+/// 50% ASCII, 50% binary - mix content
+#[divan::bench]
+fn decode_mixed_50_50(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+
+    bencher.bench_local(|| {
+        let decoded = tick_encoding::decode(divan::black_box(encoded.as_bytes())).unwrap();
+        divan::black_box(decoded);
+    });
+}
+
+/// 10% ASCII, 90% binary - mostly binary content
+#[divan::bench]
+fn decode_mixed_10_90(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+
+    bencher.bench_local(|| {
+        let decoded = tick_encoding::decode(divan::black_box(encoded.as_bytes())).unwrap();
+        divan::black_box(decoded);
+    });
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096])]
+fn decode_short_ascii(bencher: divan::Bencher, len: usize) {
+    let bytes = vec![b'a'; len];
+
+    bencher.bench_local(|| {
+        let decoded = tick_encoding::decode(divan::black_box(&bytes)).unwrap();
+        divan::black_box(decoded);
+    });
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096])]
+fn decode_short_binary(bencher: divan::Bencher, len: usize) {
+    let original = vec![0x00u8; len];
+    let encoded = tick_encoding::encode(&original);
 
     bencher.bench_local(|| {
         let decoded = tick_encoding::decode(divan::black_box(encoded.as_bytes())).unwrap();

--- a/benches/decode_in_place.rs
+++ b/benches/decode_in_place.rs
@@ -2,6 +2,7 @@ fn main() {
     divan::main();
 }
 
+/// 100% ASCII - best case (no escaping needed)
 #[divan::bench]
 fn decode_in_place_unescaped(bencher: divan::Bencher) {
     let bytes = vec![b'a'; 1_000_000];
@@ -15,6 +16,7 @@ fn decode_in_place_unescaped(bencher: divan::Bencher) {
         });
 }
 
+/// 100% tick characters
 #[divan::bench]
 fn decode_in_place_ticks(bencher: divan::Bencher) {
     let bytes = vec![b'`'; 1_000_000];
@@ -28,10 +30,59 @@ fn decode_in_place_ticks(bencher: divan::Bencher) {
         });
 }
 
+/// 100% binary - worst case (all bytes need escaping)
 #[divan::bench]
 fn decode_in_place_binary(bencher: divan::Bencher) {
-    let bytes = vec![0x00; 1];
+    let bytes = vec![0x00; 1_000_000];
     let encoded = tick_encoding::encode(&bytes);
+
+    bencher
+        .with_inputs(|| encoded.clone().into_owned().into_bytes())
+        .bench_local_values(|mut buffer| {
+            let decoded = tick_encoding::decode_in_place(divan::black_box(&mut buffer)).unwrap();
+            divan::black_box(decoded);
+        });
+}
+
+/// 90% ASCII, 10% binary - mostly text content
+#[divan::bench]
+fn decode_in_place_mixed_90_10(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+
+    bencher
+        .with_inputs(|| encoded.clone().into_owned().into_bytes())
+        .bench_local_values(|mut buffer| {
+            let decoded = tick_encoding::decode_in_place(divan::black_box(&mut buffer)).unwrap();
+            divan::black_box(decoded);
+        });
+}
+
+/// 50% ASCII, 50% binary - mix content
+#[divan::bench]
+fn decode_in_place_mixed_50_50(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+
+    bencher
+        .with_inputs(|| encoded.clone().into_owned().into_bytes())
+        .bench_local_values(|mut buffer| {
+            let decoded = tick_encoding::decode_in_place(divan::black_box(&mut buffer)).unwrap();
+            divan::black_box(decoded);
+        });
+}
+
+/// 10% ASCII, 90% binary - mostly binary content
+#[divan::bench]
+fn decode_in_place_mixed_10_90(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
 
     bencher
         .with_inputs(|| encoded.clone().into_owned().into_bytes())

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -86,7 +86,7 @@ fn encode_short_ascii(bencher: divan::Bencher, len: usize) {
 
 #[divan::bench(args = [16, 64, 256, 1024, 4096])]
 fn encode_short_binary(bencher: divan::Bencher, len: usize) {
-    let bytes = vec![0x00u8; len];
+    let bytes = vec![0x00; len];
 
     bencher.bench_local(|| {
         let encoded = tick_encoding::encode(divan::black_box(&bytes));

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -2,6 +2,7 @@ fn main() {
     divan::main();
 }
 
+/// 100% ASCII - best case (no escaping needed)
 #[divan::bench]
 fn encode_unescaped(bencher: divan::Bencher) {
     let bytes = vec![b'a'; 1_000_000];
@@ -12,6 +13,7 @@ fn encode_unescaped(bencher: divan::Bencher) {
     });
 }
 
+/// 100% tick characters
 #[divan::bench]
 fn encode_ticks(bencher: divan::Bencher) {
     let bytes = vec![b'`'; 1_000_000];
@@ -22,9 +24,69 @@ fn encode_ticks(bencher: divan::Bencher) {
     });
 }
 
+/// 100% binary - worst case (all bytes need escaping)
 #[divan::bench]
 fn encode_binary(bencher: divan::Bencher) {
     let bytes = vec![0x00; 1_000_000];
+
+    bencher.bench_local(|| {
+        let encoded = tick_encoding::encode(divan::black_box(&bytes));
+        divan::black_box(encoded);
+    });
+}
+
+/// 90% ASCII, 10% binary - mostly text content
+#[divan::bench]
+fn encode_mixed_90_10(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        let encoded = tick_encoding::encode(divan::black_box(&bytes));
+        divan::black_box(encoded);
+    });
+}
+
+/// 50% ASCII, 50% binary - mix content
+#[divan::bench]
+fn encode_mixed_50_50(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        let encoded = tick_encoding::encode(divan::black_box(&bytes));
+        divan::black_box(encoded);
+    });
+}
+
+/// 10% ASCII, 90% binary - mostly binary content
+#[divan::bench]
+fn encode_mixed_10_90(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
+        .collect();
+
+    bencher.bench_local(|| {
+        let encoded = tick_encoding::encode(divan::black_box(&bytes));
+        divan::black_box(encoded);
+    });
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096])]
+fn encode_short_ascii(bencher: divan::Bencher, len: usize) {
+    let bytes = vec![b'a'; len];
+
+    bencher.bench_local(|| {
+        let encoded = tick_encoding::encode(divan::black_box(&bytes));
+        divan::black_box(encoded);
+    });
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096])]
+fn encode_short_binary(bencher: divan::Bencher, len: usize) {
+    let bytes = vec![0x00u8; len];
 
     bencher.bench_local(|| {
         let encoded = tick_encoding::encode(divan::black_box(&bytes));

--- a/benches/functions.rs
+++ b/benches/functions.rs
@@ -1,0 +1,140 @@
+fn main() {
+    divan::main();
+}
+
+/// Benchmark requires_escape() across all byte values
+#[divan::bench]
+fn requires_escape_all_bytes(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..=255u8).collect();
+
+    bencher.bench_local(|| {
+        let mut count = 0u32;
+        for _ in 0..4000 {
+            // Repeat to get measurable time
+            for &b in &bytes {
+                if tick_encoding::requires_escape(divan::black_box(b)) {
+                    count += 1;
+                }
+            }
+        }
+        divan::black_box(count)
+    });
+}
+
+/// Benchmark encode_to_vec with unescaped content
+#[divan::bench]
+fn encode_to_vec_unescaped(bencher: divan::Bencher) {
+    let bytes = vec![b'a'; 1_000_000];
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::encode_to_vec(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark encode_to_vec with binary content (worst case)
+#[divan::bench]
+fn encode_to_vec_binary(bencher: divan::Bencher) {
+    let bytes = vec![0x00u8; 1_000_000];
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::encode_to_vec(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark encode_to_vec with mixed content
+#[divan::bench]
+fn encode_to_vec_mixed_50_50(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::encode_to_vec(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark encode_to_string with unescaped content
+#[divan::bench]
+fn encode_to_string_unescaped(bencher: divan::Bencher) {
+    let bytes = vec![b'a'; 1_000_000];
+
+    bencher.bench_local(|| {
+        let mut output = String::new();
+        tick_encoding::encode_to_string(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark encode_to_string with binary content (worst case)
+#[divan::bench]
+fn encode_to_string_binary(bencher: divan::Bencher) {
+    let bytes = vec![0x00u8; 1_000_000];
+
+    bencher.bench_local(|| {
+        let mut output = String::new();
+        tick_encoding::encode_to_string(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark encode_to_string with mixed content
+#[divan::bench]
+fn encode_to_string_mixed_50_50(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        let mut output = String::new();
+        tick_encoding::encode_to_string(divan::black_box(&bytes), &mut output);
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark decode_to_vec with unescaped content
+#[divan::bench]
+fn decode_to_vec_unescaped(bencher: divan::Bencher) {
+    let bytes = vec![b'a'; 1_000_000];
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::decode_to_vec(divan::black_box(&bytes), &mut output).unwrap();
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark decode_to_vec with binary content (worst case)
+#[divan::bench]
+fn decode_to_vec_binary(bencher: divan::Bencher) {
+    let original = vec![0x00u8; 1_000_000];
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::decode_to_vec(divan::black_box(&encoded_bytes), &mut output).unwrap();
+        divan::black_box(output)
+    });
+}
+
+/// Benchmark decode_to_vec with mixed content
+#[divan::bench]
+fn decode_to_vec_mixed_50_50(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        let mut output = Vec::new();
+        tick_encoding::decode_to_vec(divan::black_box(&encoded_bytes), &mut output).unwrap();
+        divan::black_box(output)
+    });
+}

--- a/benches/functions.rs
+++ b/benches/functions.rs
@@ -36,7 +36,7 @@ fn encode_to_vec_unescaped(bencher: divan::Bencher) {
 /// Benchmark encode_to_vec with binary content (worst case)
 #[divan::bench]
 fn encode_to_vec_binary(bencher: divan::Bencher) {
-    let bytes = vec![0x00u8; 1_000_000];
+    let bytes = vec![0x00; 1_000_000];
 
     bencher.bench_local(|| {
         let mut output = Vec::new();
@@ -74,7 +74,7 @@ fn encode_to_string_unescaped(bencher: divan::Bencher) {
 /// Benchmark encode_to_string with binary content (worst case)
 #[divan::bench]
 fn encode_to_string_binary(bencher: divan::Bencher) {
-    let bytes = vec![0x00u8; 1_000_000];
+    let bytes = vec![0x00; 1_000_000];
 
     bencher.bench_local(|| {
         let mut output = String::new();
@@ -112,7 +112,7 @@ fn decode_to_vec_unescaped(bencher: divan::Bencher) {
 /// Benchmark decode_to_vec with binary content (worst case)
 #[divan::bench]
 fn decode_to_vec_binary(bencher: divan::Bencher) {
-    let original = vec![0x00u8; 1_000_000];
+    let original = vec![0x00; 1_000_000];
     let encoded = tick_encoding::encode(&original);
     let encoded_bytes = encoded.as_bytes().to_vec();
 

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -1,0 +1,155 @@
+fn main() {
+    divan::main();
+}
+
+// ============ encode_iter benchmarks ============
+
+/// 100% ASCII - best case (no escaping needed)
+#[divan::bench]
+fn encode_iter_unescaped(bencher: divan::Bencher) {
+    let bytes = vec![b'a'; 1_000_000];
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+/// 100% tick characters
+#[divan::bench]
+fn encode_iter_ticks(bencher: divan::Bencher) {
+    let bytes = vec![b'`'; 1_000_000];
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+/// 100% binary - worst case (all bytes need escaping)
+#[divan::bench]
+fn encode_iter_binary(bencher: divan::Bencher) {
+    let bytes = vec![0x00u8; 1_000_000];
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+/// 90% ASCII, 10% binary - mostly text content
+#[divan::bench]
+fn encode_iter_mixed_90_10(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+/// 50% ASCII, 50% binary - mix content
+#[divan::bench]
+fn encode_iter_mixed_50_50(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+/// 10% ASCII, 90% binary - mostly binary content
+#[divan::bench]
+fn encode_iter_mixed_10_90(bencher: divan::Bencher) {
+    let bytes: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
+        .collect();
+
+    bencher.bench_local(|| {
+        tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
+    });
+}
+
+// ============ decode_iter benchmarks ============
+
+/// 100% ASCII - best case (no escaping needed)
+#[divan::bench]
+fn decode_iter_unescaped(bencher: divan::Bencher) {
+    let bytes = vec![b'a'; 1_000_000];
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}
+
+/// 100% tick characters
+#[divan::bench]
+fn decode_iter_ticks(bencher: divan::Bencher) {
+    let original = vec![b'`'; 1_000_000];
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}
+
+/// 100% binary - worst case (all bytes need escaping)
+#[divan::bench]
+fn decode_iter_binary(bencher: divan::Bencher) {
+    let original = vec![0x00u8; 1_000_000];
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}
+
+/// 90% ASCII, 10% binary
+#[divan::bench]
+fn decode_iter_mixed_90_10(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}
+
+/// 50% ASCII, 50% binary
+#[divan::bench]
+fn decode_iter_mixed_50_50(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}
+
+/// 10% ASCII, 90% binary
+#[divan::bench]
+fn decode_iter_mixed_10_90(bencher: divan::Bencher) {
+    let original: Vec<u8> = (0..1_000_000)
+        .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
+        .collect();
+    let encoded = tick_encoding::encode(&original);
+    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+
+    bencher.bench_local(|| {
+        tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
+            .collect::<Result<Vec<_>, _>>()
+    });
+}

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -27,7 +27,7 @@ fn encode_iter_ticks(bencher: divan::Bencher) {
 /// 100% binary - worst case (all bytes need escaping)
 #[divan::bench]
 fn encode_iter_binary(bencher: divan::Bencher) {
-    let bytes = vec![0x00u8; 1_000_000];
+    let bytes = vec![0x00; 1_000_000];
 
     bencher.bench_local(|| {
         tick_encoding::encode_iter(divan::black_box(bytes.iter().copied())).count()
@@ -88,7 +88,7 @@ fn decode_iter_unescaped(bencher: divan::Bencher) {
 fn decode_iter_ticks(bencher: divan::Bencher) {
     let original = vec![b'`'; 1_000_000];
     let encoded = tick_encoding::encode(&original);
-    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+    let encoded_bytes = encoded.as_bytes().to_vec();
 
     bencher.bench_local(|| {
         tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
@@ -99,9 +99,9 @@ fn decode_iter_ticks(bencher: divan::Bencher) {
 /// 100% binary - worst case (all bytes need escaping)
 #[divan::bench]
 fn decode_iter_binary(bencher: divan::Bencher) {
-    let original = vec![0x00u8; 1_000_000];
+    let original = vec![0x00; 1_000_000];
     let encoded = tick_encoding::encode(&original);
-    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+    let encoded_bytes = encoded.as_bytes().to_vec();
 
     bencher.bench_local(|| {
         tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
@@ -116,7 +116,7 @@ fn decode_iter_mixed_90_10(bencher: divan::Bencher) {
         .map(|i| if i % 10 == 0 { 0x00 } else { b'a' })
         .collect();
     let encoded = tick_encoding::encode(&original);
-    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+    let encoded_bytes = encoded.as_bytes().to_vec();
 
     bencher.bench_local(|| {
         tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
@@ -131,7 +131,7 @@ fn decode_iter_mixed_50_50(bencher: divan::Bencher) {
         .map(|i| if i % 2 == 0 { 0x00 } else { b'a' })
         .collect();
     let encoded = tick_encoding::encode(&original);
-    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+    let encoded_bytes = encoded.as_bytes().to_vec();
 
     bencher.bench_local(|| {
         tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))
@@ -146,7 +146,7 @@ fn decode_iter_mixed_10_90(bencher: divan::Bencher) {
         .map(|i| if i % 10 == 0 { b'a' } else { 0x00 })
         .collect();
     let encoded = tick_encoding::encode(&original);
-    let encoded_bytes: Vec<u8> = encoded.as_bytes().to_vec();
+    let encoded_bytes = encoded.as_bytes().to_vec();
 
     bencher.bench_local(|| {
         tick_encoding::decode_iter(divan::black_box(encoded_bytes.iter().copied()))


### PR DESCRIPTION
This PR adds new benchmark tests to have a better coverage of the current codebase efficiency, it adds new mixed tests by mixing:

- 90% ASCII, 10% binary
- 50% ASCII, 50% binary
- 10% ASCII, 90% binary

It'll be used by upcoming PRs to see improvements made by targeting specific area in the codebase. 