### PR TITLE
ci: run bench tests on both x86_64 and aarch64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,8 +73,15 @@ jobs:
           FEATURES: ${{ matrix.features }}
           PROPTEST_CASES: "10000"
   benchmark:
-    name: Run benchmarks
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - name: x86_64-linux
+            runs-on: ubuntu-24.04
+          - name: aarch64-linux
+            runs-on: ubuntu-24.04-arm
+    name: Run benchmarks [${{ matrix.name }}]
+    runs-on: ${{ matrix.include.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Well, maybe it would be preferable to have first the metrics for `aarch64`. So we should merge this one first @kylewlacy. This way, we could really see the improvements per architecture.