### PR TITLE
Improve "All tests passed" job in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,9 +104,21 @@ jobs:
           PROPTEST_CASES: "16"
           PROPTEST_DISABLE_FAILURE_PERSISTENCE: "true"
           MIRIFLAGS: "-Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE -Zmiri-env-forward=PROPTEST_CASES"
+
+  # Extra job that succeeds when all test jobs succeed (useful for PR requirements)
   tests-passed:
     name: All tests passed
     needs: [check, test, benchmark, miri]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
-      - run: "echo 'All tests passed'"
+      - run: |
+          test "$CHECK_RESULT" = 'success'
+          test "$TEST_RESULT" = 'success'
+          test "$BENCHMARK_RESULT" = 'success'
+          test "$MIRI_RESULT" = 'success'
+        env:
+          CHECK_RESULT: ${{ needs.check.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          BENCHMARK_RESULT: ${{ needs.benchmark.result }}
+          MIRI_RESULT: ${{ needs.miri.result }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,8 @@ name: Tests
 on:
   push:
     branches:
-      - "*"
+      - main
+      - 'build/*'
   pull_request:
   workflow_call:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           - name: aarch64-linux
             runs-on: ubuntu-24.04-arm
     name: Run benchmarks [${{ matrix.name }}]
-    runs-on: ${{ matrix.include.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to #11 to update the "All tests passed" job to better handle failed/skipped jobs. This should make it possible to use the "All tests passed" job as the main status check in a branch protection rule.

Also, I was getting a warning about the `matrix.include.runs-on` syntax from my GitHub Actions VS Code extension, so I tweaked the syntax a bit around benchmarks.