### PR TITLE
Reduce reallocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn decode(input: &[u8]) -> Result<Cow<'_, [u8]>, DecodeError> {
             // We know everything up to `index` does not need to be unescaped
             let validated = &input[..index];
 
-            let mut output = Vec::with_capacity(validated.len() + 1);
+            let mut output = Vec::with_capacity(input.len());
             output.extend_from_slice(validated);
 
             // Decode the remainder of the input


### PR DESCRIPTION
This PR should help to reduce the reallocation when encoding and decoding data.

- Encoding: the old capacity estimates were not great. When encoding, we allocated input.len() + 1 but escaped bytes take 3 characters each, so we ended up reallocating a lot.
- Decoding: we used the prefix length before the first escape which was way too small most of the time.

Now there's a helper that estimates 1.5x the input size for encoding, should be enough for most cases. For decoding we just use the input length directly since the output is always smaller or equal anyway.