### PR TITLE
Rewrite encoder state machine

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,6 +10,7 @@ pub enum Decoder {
 }
 
 impl Decoder {
+    #[inline]
     pub fn push(&mut self, input: Option<u8>) -> DecodeStatus {
         match (*self, input) {
             (Self::Finished, _) => DecodeStatus::Emit(None),

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,40 +1,55 @@
-use crate::{byte_to_hex_chars, requires_escape};
+use crate::{nibble_to_hex, requires_escape};
 
-#[derive(Debug, Default, Clone, Copy)]
-pub enum Encoder {
-    #[default]
-    Ready,
-    EmitOne([char; 1]),
-    EmitTwo([char; 2]),
+/// Encoder state machine.
+#[derive(Debug, Clone, Copy)]
+pub struct Encoder {
+    /// Precomputed characters to emit.
+    chars: [u8; 2],
+    /// Count of remaining characters to emit: 0, 1, or 2.
+    pending: u8,
+}
+
+impl Default for Encoder {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            chars: [0, 0],
+            pending: 0,
+        }
+    }
 }
 
 impl Encoder {
     #[inline]
     pub fn next(&mut self) -> Option<char> {
-        match *self {
-            Self::Ready => None,
-            Self::EmitOne([byte]) => {
-                *self = Self::Ready;
-                Some(byte)
-            }
-            Self::EmitTwo([a, b]) => {
-                *self = Self::EmitOne([b]);
-                Some(a)
-            }
+        if self.pending == 0 {
+            return None;
         }
+
+        // Map pending count to array index:
+        // - pending = 2 → index = 0 (first)
+        // - pending = 1 → index = 1 (second)
+        let index = (2 - self.pending) as usize;
+        self.pending -= 1;
+
+        Some(self.chars[index] as char)
     }
 
     #[inline]
     pub fn push(&mut self, byte: u8) -> char {
         if byte == b'`' {
-            *self = Self::EmitOne(['`']);
+            // Store at index = 1 because next() will access:
+            // - pending = 1 → index = 1
+            self.chars[1] = b'`';
+            self.pending = 1;
             '`'
         } else if requires_escape(byte) {
-            let hex = byte_to_hex_chars(byte);
-            *self = Self::EmitTwo(hex);
+            self.chars[0] = nibble_to_hex(byte >> 4);
+            self.chars[1] = nibble_to_hex(byte & 0x0F);
+            self.pending = 2;
             '`'
         } else {
-            *self = Self::Ready;
+            self.pending = 0;
             byte as char
         }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,6 +9,7 @@ pub enum Encoder {
 }
 
 impl Encoder {
+    #[inline]
     pub fn next(&mut self) -> Option<char> {
         match *self {
             Self::Ready => None,
@@ -23,6 +24,7 @@ impl Encoder {
         }
     }
 
+    #[inline]
     pub fn push(&mut self, byte: u8) -> char {
         if byte == b'`' {
             *self = Self::EmitOne(['`']);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,6 +12,7 @@ pub struct EncodeIter<I> {
 }
 
 impl<I> EncodeIter<I> {
+    #[inline]
     pub(crate) fn new(iter: I) -> Self {
         Self {
             iter,
@@ -20,16 +21,19 @@ impl<I> EncodeIter<I> {
     }
 
     /// Get a reference to the inner iterator.
+    #[inline]
     pub const fn inner(&self) -> &I {
         &self.iter
     }
 
     /// Get a mutable reference to the inner iterator.
+    #[inline]
     pub fn inner_mut(&mut self) -> &mut I {
         &mut self.iter
     }
 
     /// Take the inner iterator.
+    #[inline]
     pub fn into_inner(self) -> I {
         self.iter
     }
@@ -41,6 +45,7 @@ where
 {
     type Item = char;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(encoded) = self.encoder.next() {
             return Some(encoded);
@@ -60,6 +65,7 @@ pub struct DecodeIter<I> {
 }
 
 impl<I> DecodeIter<I> {
+    #[inline]
     pub(crate) fn new(iter: I) -> Self {
         Self {
             iter,
@@ -68,16 +74,19 @@ impl<I> DecodeIter<I> {
     }
 
     /// Get a reference to the inner iterator.
+    #[inline]
     pub const fn inner(&self) -> &I {
         &self.iter
     }
 
     /// Get a mutable reference to the inner iterator.
+    #[inline]
     pub fn inner_mut(&mut self) -> &mut I {
         &mut self.iter
     }
 
     /// Take the inner iterator.
+    #[inline]
     pub fn into_inner(self) -> I {
         self.iter
     }
@@ -89,6 +98,7 @@ where
 {
     type Item = Result<u8, DecodeError>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let next_byte = self.iter.next();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,7 @@ pub fn decode_in_place(input: &mut [u8]) -> Result<&mut [u8], DecodeError> {
 /// - Carriage return (`\r`, 0x0D)
 /// - Space (` `, 0x20)
 /// - Printable characters except backtick (0x21 to 0x59, 0x61 to 0x7E)
+#[inline]
 #[must_use]
 pub const fn requires_escape(byte: u8) -> bool {
     REQUIRES_ESCAPE_TABLE[byte as usize]
@@ -392,6 +393,7 @@ pub fn decode_to_vec(input: &[u8], output: &mut Vec<u8>) -> Result<usize, Decode
 }
 
 /// Convert a nibble to its uppercase hex ASCII character.
+#[inline]
 const fn nibble_to_hex(n: u8) -> u8 {
     // 0-9 → '0'-'9'
     // 10-15 → 'A'-'F' (add 7 to skip the ASCII gap between '9' and 'A')
@@ -399,6 +401,7 @@ const fn nibble_to_hex(n: u8) -> u8 {
 }
 
 /// Convert a byte to its two-character uppercase hex representation.
+#[inline]
 const fn byte_to_hex_bytes(byte: u8) -> [u8; 2] {
     [nibble_to_hex(byte >> 4), nibble_to_hex(byte & 0x0F)]
 }
@@ -414,6 +417,7 @@ const fn byte_to_hex_chars(byte: u8) -> [char; 2] {
 /// - Either character is not a valid hex digit (`InvalidHex`)
 /// - Either character is lowercase a-f (`LowercaseHex`)
 /// - The decoded byte doesn't require escaping (`UnexpectedEscape`)
+#[inline]
 const fn hex_bytes_to_byte(high: u8, low: u8) -> Result<u8, DecodeError> {
     let high_value = HEX_NIBBLE_DECODE_TABLE[high as usize];
     let low_value = HEX_NIBBLE_DECODE_TABLE[low as usize];


### PR DESCRIPTION
Based on #9 

This PR reduces the stack size of `Encoder`:

| Main (enum) | PR (struct) |
|-------------|-------------|
| 8 bytes | 3 bytes |

Main uses an enum with three variants:

```rust
pub enum Encoder {
    Ready,
    EmitOne([char; 1]),  // 4 bytes
    EmitTwo([char; 2]),  // 8 bytes
}
```

While this PR uses a compact struct:

```rust
pub struct Encoder {
    chars: [u8; 2],  // 2 bytes
    pending: u8,     // 1 byte
}
```