### PR TITLE
Add benchmark PR comment

### DIFF
--- a/.github/scripts/compare_benchmarks.py
+++ b/.github/scripts/compare_benchmarks.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Compare benchmark results between base and PR branches.
+
+Generates a markdown report showing performance changes with indicators.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ComparisonStatus(Enum):
+    """Status of a benchmark comparison."""
+
+    COMPARED = "compared"
+    NEW = "new"
+    REMOVED = "removed"
+
+
+@dataclass
+class BenchmarkComparison:
+    """Result of comparing a benchmark between base and PR."""
+
+    name: str
+    base: int | None
+    pr: int | None
+    change_pct: float | None
+    indicator: str
+    status: ComparisonStatus
+
+
+def format_time(ns: int | None) -> str:
+    """Format nanoseconds to human-readable time string.
+
+    Handles edge cases:
+    - Zero returns "0 ns"
+    - Negative values are formatted with a minus sign
+    - None returns "N/A"
+    """
+    if ns is None:
+        return "N/A"
+
+    if ns == 0:
+        return "0 ns"
+
+    sign = "-" if ns < 0 else ""
+    abs_ns = abs(ns)
+
+    if abs_ns >= 1_000_000_000:
+        return f"{sign}{abs_ns / 1_000_000_000:.3f} s"
+    if abs_ns >= 1_000_000:
+        return f"{sign}{abs_ns / 1_000_000:.3f} ms"
+    if abs_ns >= 1_000:
+        return f"{sign}{abs_ns / 1_000:.3f} µs"
+    return f"{sign}{abs_ns} ns"
+
+
+def calculate_change(base: int, pr: int) -> float:
+    """Calculate percentage change from base to PR."""
+    if base == 0:
+        return 0.0
+    return ((pr - base) / base) * 100
+
+
+def get_change_indicator(
+    change_pct: float,
+    improvement_threshold: float = -0.5,
+    warn_threshold: float = 5.0,
+    error_threshold: float = 10.0,
+) -> str:
+    """Get indicator emoji based on change percentage.
+
+    Args:
+        change_pct: The percentage change (positive = slower, negative = faster)
+        improvement_threshold: Threshold for improvement (default: -0.5, i.e., 0.5% faster)
+        warn_threshold: Threshold for warning (default: 5.0%)
+        error_threshold: Threshold for error/regression (default: 10.0%)
+    """
+    if change_pct <= improvement_threshold:
+        return "✅"
+    if change_pct > error_threshold:
+        return "❌"
+    if change_pct > warn_threshold:
+        return "⚠️"
+
+    return ""
+
+
+def validate_benchmark_entry(
+    entry: dict[str, Any], file_path: Path, index: int, metric: str
+) -> None:
+    """Validate a single benchmark entry has required fields.
+
+    Raises:
+        ValueError: If required fields are missing.
+    """
+    if "name" not in entry:
+        raise ValueError(
+            f"Entry {index} in '{file_path}' missing required field 'name'"
+        )
+    if metric not in entry:
+        raise ValueError(
+            f"Benchmark '{entry.get('name', f'entry {index}')}' in '{file_path}' missing metric '{metric}'"
+        )
+    if "value" not in entry.get(metric, {}):
+        raise ValueError(
+            f"Benchmark '{entry['name']}' in '{file_path}' has metric '{metric}' but no 'value' field"
+        )
+
+
+def load_benchmarks(file_path: str | Path, metric: str) -> dict[str, dict[str, Any]]:
+    """Load benchmarks from JSON file and return as dict keyed by name.
+
+    Args:
+        file_path: Path to the JSON benchmark file.
+        metric: The metric to validate (e.g., "mean", "median").
+
+    Returns:
+        Dictionary mapping benchmark names to their data.
+    """
+    path = Path(file_path)
+
+    if not path.exists():
+        print(f"Error: File '{path}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in '{path}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print(
+            f"Error: Expected JSON array in '{path}', got {type(data).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Validate each entry
+    for index, entry in enumerate(data):
+        try:
+            validate_benchmark_entry(entry, path, index, metric)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    return {item["name"]: item for item in data}
+
+
+def get_benchmark_group(name: str) -> str:
+    """Extract the main group from a benchmark name."""
+    return name.split("/")[0] if "/" in name else name
+
+
+def format_group_name(group: str) -> str:
+    """Format group name for section header."""
+    return group.replace("_", " ").title()
+
+
+def get_short_name(name: str) -> str:
+    """Get benchmark name without group prefix."""
+    parts = name.split("/", 1)
+    return parts[1] if len(parts) > 1 else name
+
+
+def format_table_row(comparison: BenchmarkComparison, display_name: str | None = None) -> str:
+    """Format a single comparison as a markdown table row.
+
+    Args:
+        comparison: The benchmark comparison data.
+        display_name: Optional name to display instead of comparison.name.
+    """
+    name = display_name if display_name else comparison.name
+    base_str = format_time(comparison.base)
+    pr_str = format_time(comparison.pr)
+
+    if comparison.change_pct is not None:
+        change_str = f"{comparison.change_pct:+.1f}% {comparison.indicator}".strip()
+    else:
+        change_str = comparison.indicator
+
+    return f"| `{name}` | {base_str} | {pr_str} | {change_str} |"
+
+
+def generate_comparison(
+    base_benchmarks: dict[str, dict[str, Any]],
+    pr_benchmarks: dict[str, dict[str, Any]],
+    metric: str = "mean",
+    improvement_threshold: float = -0.5,
+    warn_threshold: float = 5.0,
+    error_threshold: float = 10.0,
+) -> list[BenchmarkComparison]:
+    """Generate comparison data between base and PR benchmarks.
+
+    Args:
+        base_benchmarks: Benchmarks from the base branch.
+        pr_benchmarks: Benchmarks from the PR branch.
+        metric: The metric to compare (default: "mean").
+        improvement_threshold: Threshold for improvement indicator.
+        warn_threshold: Threshold for warning indicator.
+        error_threshold: Threshold for error indicator.
+
+    Returns:
+        List of BenchmarkComparison objects.
+    """
+    comparisons: list[BenchmarkComparison] = []
+
+    all_names = sorted(set(base_benchmarks.keys()) | set(pr_benchmarks.keys()))
+
+    for name in all_names:
+        base_data = base_benchmarks.get(name)
+        pr_data = pr_benchmarks.get(name)
+
+        if base_data and pr_data:
+            base_value = base_data[metric]["value"]
+            pr_value = pr_data[metric]["value"]
+            change_pct = calculate_change(base_value, pr_value)
+
+            comparisons.append(
+                BenchmarkComparison(
+                    name=name,
+                    base=base_value,
+                    pr=pr_value,
+                    change_pct=change_pct,
+                    indicator=get_change_indicator(
+                        change_pct,
+                        improvement_threshold,
+                        warn_threshold,
+                        error_threshold,
+                    ),
+                    status=ComparisonStatus.COMPARED,
+                )
+            )
+        elif pr_data and not base_data:
+            comparisons.append(
+                BenchmarkComparison(
+                    name=name,
+                    base=None,
+                    pr=pr_data[metric]["value"],
+                    change_pct=None,
+                    indicator="🆕",
+                    status=ComparisonStatus.NEW,
+                )
+            )
+        elif base_data and not pr_data:
+            comparisons.append(
+                BenchmarkComparison(
+                    name=name,
+                    base=base_data[metric]["value"],
+                    pr=None,
+                    change_pct=None,
+                    indicator="🗑️",
+                    status=ComparisonStatus.REMOVED,
+                )
+            )
+
+    return comparisons
+
+
+def generate_markdown(
+    comparisons: list[BenchmarkComparison],
+    title: str,
+    subtitle: str | None = None,
+    warn_threshold: float = 5.0,
+    improvement_threshold: float = -0.5,
+) -> str:
+    """Generate markdown report from comparison data.
+
+    Args:
+        comparisons: List of benchmark comparisons.
+        title: Title for the report header.
+        subtitle: Optional subtitle displayed below the title.
+        warn_threshold: Threshold for regression detection.
+        improvement_threshold: Threshold for improvement detection.
+
+    Returns:
+        Markdown-formatted report string.
+    """
+    lines: list[str] = []
+
+    # Count regressions and improvements
+    regressions = [c for c in comparisons if (c.change_pct or 0) > warn_threshold]
+    improvements = [
+        c for c in comparisons if (c.change_pct or 0) < improvement_threshold
+    ]
+
+    lines.append(f"## {title}")
+    if subtitle:
+        lines.append("")
+        lines.append(f"<sub>{subtitle}</sub>")
+    lines.append("")
+
+    if not comparisons:
+        lines.append("No benchmark data available.")
+        return "\n".join(lines)
+
+    # Summary
+    if regressions:
+        lines.append(
+            f"**{len(regressions)} potential regression(s)** detected (>{warn_threshold}% slower)"
+        )
+    if improvements:
+        lines.append(f"**{len(improvements)} improvement(s)** detected")
+
+    # Group benchmarks by category
+    groups: dict[str, list[BenchmarkComparison]] = {}
+    for c in comparisons:
+        group = get_benchmark_group(c.name)
+        if group not in groups:
+            groups[group] = []
+        groups[group].append(c)
+
+    # Sort groups alphabetically
+    sorted_groups = sorted(groups.keys())
+
+    # Generate a section for each group
+    for group in sorted_groups:
+        group_comparisons = groups[group]
+        lines.append("")
+        lines.append(f"### {format_group_name(group)}")
+        lines.append("")
+        lines.append("| Benchmark | Base | PR | Change |")
+        lines.append("|-----------|------|-----|--------|")
+
+        for c in group_comparisons:
+            short_name = get_short_name(c.name)
+            lines.append(format_table_row(c, short_name))
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compare benchmark results between base and PR"
+    )
+    parser.add_argument("base_file", help="Path to base benchmark JSON file")
+    parser.add_argument("pr_file", help="Path to PR benchmark JSON file")
+    parser.add_argument(
+        "--title",
+        default="Benchmarks",
+        help="Title for the report header",
+    )
+    parser.add_argument(
+        "--subtitle",
+        help="Subtitle displayed below the title",
+    )
+    parser.add_argument(
+        "--metric",
+        default="mean",
+        choices=["fastest", "slowest", "median", "mean"],
+        help="Metric to use for comparison (default: mean)",
+    )
+    parser.add_argument(
+        "--improvement-threshold",
+        type=float,
+        default=0.5,
+        help="Threshold for detecting improvements (default: 0.5%%)",
+    )
+    parser.add_argument(
+        "--warn-threshold",
+        type=float,
+        default=5.0,
+        help="Threshold for warning indicator (default: 5.0%%)",
+    )
+    parser.add_argument(
+        "--error-threshold",
+        type=float,
+        default=10.0,
+        help="Threshold for error/regression indicator (default: 10.0%%)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file (default: stdout)",
+    )
+
+    args = parser.parse_args()
+
+    # Convert improvement threshold to negative
+    improvement_threshold = -abs(args.improvement_threshold)
+
+    base_benchmarks = load_benchmarks(args.base_file, args.metric)
+    pr_benchmarks = load_benchmarks(args.pr_file, args.metric)
+
+    comparisons = generate_comparison(
+        base_benchmarks,
+        pr_benchmarks,
+        args.metric,
+        improvement_threshold=improvement_threshold,
+        warn_threshold=args.warn_threshold,
+        error_threshold=args.error_threshold,
+    )
+    markdown = generate_markdown(
+        comparisons,
+        args.title,
+        subtitle=args.subtitle,
+        warn_threshold=args.warn_threshold,
+        improvement_threshold=improvement_threshold,
+    )
+
+    if args.output:
+        Path(args.output).write_text(markdown)
+    else:
+        print(markdown)

--- a/.github/scripts/parse_divan.py
+++ b/.github/scripts/parse_divan.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Parse Divan benchmark output to JSON format.
+
+Divan (https://github.com/nvzqz/divan) outputs benchmark results in a
+tree-table format. This script converts that output to JSON for further
+processing, such as benchmark comparisons in CI pipelines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Matches time values like "1.816 ms", "710.1 µs", "500 ns"
+TIME_PATTERN = re.compile(r"([\d.]+)\s*(ns|µs|us|ms|s)")
+
+# Matches lines starting with tree-drawing characters (├, │, └, ╰, ─)
+TREE_LINE_PATTERN = re.compile(r"^\s*[├│└╰─]")
+
+# Matches benchmark data lines, including nested ones like "│  ├─ 16   <data...>"
+BENCH_LINE_PATTERN = re.compile(r"^\s*(?:│\s*)*[├└╰]─\s*(\S+)\s+(.*)")
+
+# Splits on column separators (│) with optional surrounding whitespace
+COLUMN_SPLIT_PATTERN = re.compile(r"\s*│\s*")
+
+
+@dataclass
+class TimeValue:
+    """Represents a time measurement with value in nanoseconds."""
+
+    value: int | None
+    unit: str = "ns"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {"value": self.value, "unit": self.unit}
+
+
+@dataclass
+class BenchmarkResult:
+    """Represents a single benchmark result with all timing metrics."""
+
+    name: str
+    fastest: TimeValue
+    slowest: TimeValue
+    median: TimeValue
+    mean: TimeValue
+    samples: int | None
+    iters: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "fastest": self.fastest.to_dict(),
+            "slowest": self.slowest.to_dict(),
+            "median": self.median.to_dict(),
+            "mean": self.mean.to_dict(),
+            "samples": self.samples,
+            "iters": self.iters,
+        }
+
+    def validate(self) -> list[str]:
+        """Validate benchmark result for consistency.
+
+        Returns a list of warning messages. Empty list means valid.
+        """
+        warnings: list[str] = []
+
+        # Check timing consistency: fastest <= median <= slowest
+        if (
+            self.fastest.value is not None
+            and self.median.value is not None
+            and self.slowest.value is not None
+        ):
+            if self.fastest.value > self.median.value:
+                warnings.append(
+                    f"{self.name}: fastest ({self.fastest.value}) > "
+                    f"median ({self.median.value})"
+                )
+            if self.median.value > self.slowest.value:
+                warnings.append(
+                    f"{self.name}: median ({self.median.value}) > "
+                    f"slowest ({self.slowest.value})"
+                )
+
+        # Check samples is positive
+        if self.samples is not None and self.samples <= 0:
+            warnings.append(
+                f"{self.name}: samples must be positive, got {self.samples}"
+            )
+
+        # Check iters is positive
+        if self.iters is not None and self.iters <= 0:
+            warnings.append(f"{self.name}: iters must be positive, got {self.iters}")
+
+        return warnings
+
+
+def parse_time_to_ns(time_str: str) -> int | None:
+    """Convert a time string to nanoseconds.
+
+    Accepts formats like '1.816 ms', '710.1 µs', '500 ns', '1.5 s'.
+
+    Args:
+        time_str: Time string to parse
+
+    Returns:
+        Time value in nanoseconds, or None if parsing fails
+    """
+    time_str = time_str.strip()
+    if not time_str:
+        return None
+
+    match = TIME_PATTERN.match(time_str)
+    if not match:
+        return None
+
+    value = float(match.group(1))
+    unit = match.group(2)
+
+    multipliers: dict[str, int] = {
+        "ns": 1,
+        "µs": 1_000,
+        "us": 1_000,
+        "ms": 1_000_000,
+        "s": 1_000_000_000,
+    }
+
+    return int(value * multipliers.get(unit, 1))
+
+
+def parse_int(value_str: str) -> int | None:
+    """Parse an integer from a string.
+
+    Args:
+        value_str: String to parse
+
+    Returns:
+        Parsed integer, or None if parsing fails
+    """
+    value_str = value_str.strip()
+    if not value_str:
+        return None
+    try:
+        return int(value_str)
+    except ValueError:
+        return None
+
+
+def parse_line(
+    line: str, current_group: str, current_subgroup: str
+) -> BenchmarkResult | str | None:
+    """Parse a single benchmark data line.
+
+    Args:
+        line: The line to parse (should match BENCH_LINE_PATTERN)
+        current_group: The current benchmark group name
+        current_subgroup: The current benchmark subgroup name (for nested benchmarks)
+
+    Returns:
+        BenchmarkResult if line contains valid benchmark data,
+        str (new subgroup name) if line is a subgroup header,
+        None if line doesn't match.
+    """
+    match = BENCH_LINE_PATTERN.match(line)
+    if not match:
+        return None
+
+    bench_name = match.group(1)
+    rest = match.group(2)
+
+    # Split by │ to get timing columns
+    columns = COLUMN_SPLIT_PATTERN.split(rest)
+    if len(columns) < 6:
+        return None
+
+    # Columns are: fastest, slowest, median, mean, samples, iters
+    fastest_ns = parse_time_to_ns(columns[0])
+    slowest_ns = parse_time_to_ns(columns[1])
+    median_ns = parse_time_to_ns(columns[2])
+    mean_ns = parse_time_to_ns(columns[3])
+    samples = parse_int(columns[4])
+    iters = parse_int(columns[5])
+
+    # If no timing data, this is a subgroup header
+    if mean_ns is None:
+        return bench_name
+
+    # Build full benchmark name with optional subgroup
+    if current_subgroup:
+        full_name = f"{current_group}/{current_subgroup}/{bench_name}"
+    elif current_group:
+        full_name = f"{current_group}/{bench_name}"
+    else:
+        full_name = bench_name
+
+    return BenchmarkResult(
+        name=full_name,
+        fastest=TimeValue(fastest_ns),
+        slowest=TimeValue(slowest_ns),
+        median=TimeValue(median_ns),
+        mean=TimeValue(mean_ns),
+        samples=samples,
+        iters=iters,
+    )
+
+
+def parse_divan_output(content: str) -> list[BenchmarkResult]:
+    """Parse Divan benchmark output and return list of benchmark results.
+
+    This is a pure function with no side effects.
+
+    Args:
+        content: Raw Divan benchmark output text
+
+    Returns:
+        List of BenchmarkResult objects
+    """
+    results: list[BenchmarkResult] = []
+    current_group = ""
+    current_subgroup = ""
+
+    for line in content.splitlines():
+        # Skip empty lines
+        if not line.strip():
+            continue
+
+        # Check for header lines (contain column names: fastest, slowest, median)
+        # Extract group name from the beginning of the header before skipping
+        if "fastest" in line and "slowest" in line and "median" in line:
+            parts = COLUMN_SPLIT_PATTERN.split(line)
+            if parts:
+                # The group name is at the start of the line, before "fastest"
+                first_part = parts[0].strip()
+                words = first_part.split()
+                # Filter out "fastest" if it's in the first part
+                group_words = [w for w in words if w != "fastest"]
+                if group_words:
+                    current_group = group_words[0]
+                    current_subgroup = ""  # Reset subgroup on new group
+            continue
+
+        # Check for group header (line without tree characters)
+        # Group headers are lines that don't start with tree chars (├, │, └)
+        if not TREE_LINE_PATTERN.match(line):
+            # Check if this is a group name (no timing data)
+            parts = COLUMN_SPLIT_PATTERN.split(line)
+            if len(parts) == 1 or (len(parts) > 1 and not parse_time_to_ns(parts[1])):
+                # This might be a group header
+                stripped = line.strip()
+                if stripped and not stripped.startswith("Timer precision"):
+                    current_group = stripped.split()[0] if stripped.split() else ""
+                    current_subgroup = ""  # Reset subgroup on new group
+                continue
+            continue
+
+        # Parse benchmark line with tree structure
+        # Check if this is a nested line (starts with │) or top-level
+        is_nested = line.lstrip().startswith("│")
+        if not is_nested:
+            # Top-level benchmark line, reset subgroup
+            current_subgroup = ""
+
+        result = parse_line(line, current_group, current_subgroup)
+        if isinstance(result, str):
+            # Got a subgroup name
+            current_subgroup = result
+        elif isinstance(result, BenchmarkResult):
+            results.append(result)
+
+    return results
+
+
+def read_input(path: str) -> str:
+    """Read input from file or stdin.
+
+    Args:
+        path: File path, or '-' to read from stdin
+
+    Returns:
+        File contents as string
+    """
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text()
+
+
+def write_output(content: str, path: str | None) -> None:
+    """Write output to file or stdout.
+
+    Args:
+        content: Content to write
+        path: File path, or None to write to stdout
+    """
+    if path is None:
+        sys.stdout.write(content)
+    else:
+        Path(path).write_text(content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Parse Divan benchmark output to JSON format.",
+    )
+    parser.add_argument(
+        "input",
+        help="Input file path, or '-' to read from stdin",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: stdout)",
+    )
+
+    args = parser.parse_args()
+
+    # Read input
+    try:
+        content = read_input(args.input)
+    except FileNotFoundError:
+        print(f"Error: File '{args.input}' not found", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error: Failed to read '{args.input}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse benchmark output
+    results = parse_divan_output(content)
+
+    # Convert to JSON
+    json_data = [result.to_dict() for result in results]
+    json_output = json.dumps(json_data, indent=2) + "\n"
+
+    # Write output
+    try:
+        write_output(json_output, args.output)
+    except OSError as e:
+        print(f"Error: Failed to write output: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,46 @@
+name: Post Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post benchmark comment (${{ matrix.name }})
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        name: [x86_64-linux, aarch64-linux]
+    steps:
+      - name: Download benchmark report
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-report-${{ matrix.name }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" \
+            --jq '.pull_requests[0].number')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update benchmark comment
+        if: steps.pr.outputs.number
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: benchmark-${{ matrix.name }}
+          number: ${{ steps.pr.outputs.number }}
+          path: comment-body.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'build/*'
+      - "build/*"
   pull_request:
   workflow_call:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
   workflow_call:
 
 env:
+  STABLE_TOOLCHAIN: 1.93.0
   NIGHTLY_TOOLCHAIN: nightly-2026-01-05
 
 jobs:
@@ -86,8 +87,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Install Rust stable toolchain
+        run: rustup toolchain install "$STABLE_TOOLCHAIN"
       - name: Run benchmarks
-        run: cargo bench
+        run: cargo +"$STABLE_TOOLCHAIN" bench
   miri:
     name: Run Miri tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Save benchmark scripts
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p /tmp/bench-scripts
+          cp .github/scripts/parse_divan.py /tmp/bench-scripts/
+          cp .github/scripts/compare_benchmarks.py /tmp/bench-scripts/
+
       - name: Install Rust stable toolchain
         run: rustup toolchain install "$STABLE_TOOLCHAIN"
 
@@ -97,7 +104,7 @@ jobs:
       - name: Parse head benchmark results
         if: github.event_name == 'pull_request'
         run: |
-          .github/scripts/parse_divan.py \
+          /tmp/bench-scripts/parse_divan.py \
             head-benchmark.txt \
             --output head-benchmark.json
 
@@ -115,14 +122,14 @@ jobs:
       - name: Parse base benchmark results
         if: github.event_name == 'pull_request'
         run: |
-          .github/scripts/parse_divan.py \
+          /tmp/bench-scripts/parse_divan.py \
             base-benchmark.txt \
             --output base-benchmark.json
 
       - name: Generate comparison report
         if: github.event_name == 'pull_request'
         run: |
-          .github/scripts/compare_benchmarks.py \
+          /tmp/bench-scripts/compare_benchmarks.py \
             base-benchmark.json \
             head-benchmark.json \
             --title "Benchmark Results (${{ matrix.name }})" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,10 +87,55 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
       - name: Install Rust stable toolchain
         run: rustup toolchain install "$STABLE_TOOLCHAIN"
-      - name: Run benchmarks
-        run: cargo +"$STABLE_TOOLCHAIN" bench
+
+      - name: Run head benchmarks
+        run: cargo +"$STABLE_TOOLCHAIN" bench 2>&1 | tee head-benchmark.txt
+
+      - name: Parse head benchmark results
+        if: github.event_name == 'pull_request'
+        run: |
+          .github/scripts/parse_divan.py \
+            head-benchmark.txt \
+            --output head-benchmark.json
+
+      - name: Checkout base branch
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          clean: false
+
+      - name: Run base benchmarks
+        if: github.event_name == 'pull_request'
+        run: cargo +"$STABLE_TOOLCHAIN" bench 2>&1 | tee base-benchmark.txt
+
+      - name: Parse base benchmark results
+        if: github.event_name == 'pull_request'
+        run: |
+          .github/scripts/parse_divan.py \
+            base-benchmark.txt \
+            --output base-benchmark.json
+
+      - name: Generate comparison report
+        if: github.event_name == 'pull_request'
+        run: |
+          .github/scripts/compare_benchmarks.py \
+            base-benchmark.json \
+            head-benchmark.json \
+            --title "Benchmark Results (${{ matrix.name }})" \
+            --subtitle "Comparing ${{ github.event.pull_request.head.sha }} (head) vs ${{ github.event.pull_request.base.sha }} (base)" \
+            --output comment-body.md
+
+      - name: Upload benchmark report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark-report-${{ matrix.name }}
+          path: comment-body.md
+          retention-days: 7
   miri:
     name: Run Miri tests
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR reduces the burden of generating benchmark reports for each PR targeting this repository. We want to ensure that the performance will not degrade on any upcoming PRs, and thus for that, it would be important to have access to these metrics more easily.

Unfortunately, Divan does not generate machine readable output (aka JSON output), only human readable output. So, I created two scripts, one to parse the Divan outputs and the other ones to create benchmark report (with the base PR branch (most of the time main) as the reference). All the tests jobs are now done on the same runner, to make things more comparable (between the base branch and the PR). Previously, we could have ended up running a base benchmark on runner A, and the PR benchmark on runner B. And, we have no guarantee from GitHub that both runners will have the EXACT same CPU / RAM / etc.
Also, all the benchmark tests are now pinned to a specific Rust stable version (which is greater than the MSRV), locally the metrics were totally different (than the ones from the CI). After investigation, it seems the output LLVM IR wasn't the same, and I think it was due to the fact that the CI was using Rust 1.70 and I was using 1.92. Using newer version of Rust here should help to generate LLVM IR similar to the ones generated locally (since developers tend to follow newest releases of Rust).