### PR TITLE
fix: correctly set the output capacity when decoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub fn decode(input: &[u8]) -> Result<Cow<'_, [u8]>, DecodeError> {
             // We know everything up to `index` does not need to be unescaped
             let validated = &input[..index];
 
-            let mut output = Vec::with_capacity(validated.len() + 1);
+            let mut output = Vec::with_capacity(input.len());
             output.extend_from_slice(validated);
 
             // Decode the remainder of the input


### PR DESCRIPTION
Extracted from https://github.com/kylewlacy/tick-encoding/pull/13. This PR updates one vec pre allocation to fit the entire input data instead of a sub part.

The base reference is #14 (but the gain should be the same on main).

## Benchmarks

**35 improvement(s)** detected

### Decode

| Benchmark | Base | PR | Change |
|-----------|------|-----|--------|
| `decode_binary` | 1.600 ms | 1.570 ms | -1.9% ✅ |
| `decode_mixed_10_90` | 1.507 ms | 1.480 ms | -1.8% ✅ |
| `decode_mixed_50_50` | 1.279 ms | 1.262 ms | -1.3% ✅ |
| `decode_mixed_90_10` | 801.000 µs | 787.000 µs | -1.7% ✅ |
| `decode_short_ascii/1024` | 338 ns | 348 ns | +3.0% |
| `decode_short_ascii/16` | 6 ns | 6 ns | 0% |
| `decode_short_ascii/256` | 98 ns | 96 ns | -2.0% ✅ |
| `decode_short_ascii/4096` | 1.362 µs | 1.319 µs | -3.2% ✅ |
| `decode_short_ascii/64` | 21 ns | 21 ns | +0.0% |
| `decode_short_binary/1024` | 2.029 µs | 1.664 µs | -18.0% ✅ |
| `decode_short_binary/16` | 89 ns | 59 ns | -33.7% ✅ |
| `decode_short_binary/256` | 691 ns | 445 ns | -35.6% ✅ |
| `decode_short_binary/4096` | 7.135 µs | 6.646 µs | -6.9% ✅ |
| `decode_short_binary/64` | 247 ns | 142 ns | -42.5% ✅ |
| `decode_ticks` | 947.000 µs | 941.600 µs | -0.6% ✅ |
| `decode_unescaped` | 314.600 µs | 314.900 µs | +0.1% |

### Decode In Place

| Benchmark | Base | PR | Change |
|-----------|------|-----|--------|
| `decode_in_place_binary` | 1.567 ms | 1.565 ms | -0.1% |
| `decode_in_place_mixed_10_90` | 1.475 ms | 1.485 ms | +0.7% |
| `decode_in_place_mixed_50_50` | 1.098 ms | 1.107 ms | +0.8% |
| `decode_in_place_mixed_90_10` | 720.300 µs | 725.500 µs | +0.7% |
| `decode_in_place_ticks` | 783.300 µs | 787.000 µs | +0.5% |
| `decode_in_place_unescaped` | 315.100 µs | 313.000 µs | -0.7% ✅ |

### Encode

| Benchmark | Base | PR | Change |
|-----------|------|-----|--------|
| `encode_binary` | 1.567 ms | 1.544 ms | -1.5% ✅ |
| `encode_mixed_10_90` | 1.493 ms | 1.474 ms | -1.3% ✅ |
| `encode_mixed_50_50` | 1.266 ms | 1.254 ms | -0.9% ✅ |
| `encode_mixed_90_10` | 1.011 ms | 1.000 ms | -1.1% ✅ |
| `encode_short_ascii/1024` | 373 ns | 360 ns | -3.5% ✅ |
| `encode_short_ascii/16` | 8 ns | 8 ns | +0.0% |
| `encode_short_ascii/256` | 105 ns | 104 ns | -1.0% ✅ |
| `encode_short_ascii/4096` | 1.421 µs | 1.425 µs | +0.3% |
| `encode_short_ascii/64` | 24 ns | 25 ns | +4.2% |
| `encode_short_binary/1024` | 1.768 µs | 1.782 µs | +0.8% |
| `encode_short_binary/16` | 160 ns | 161 ns | +0.6% |
| `encode_short_binary/256` | 578 ns | 559 ns | -3.3% ✅ |
| `encode_short_binary/4096` | 6.622 µs | 6.735 µs | +1.7% |
| `encode_short_binary/64` | 230 ns | 231 ns | +0.4% |
| `encode_ticks` | 715.400 µs | 709.400 µs | -0.8% ✅ |
| `encode_unescaped` | 352.800 µs | 346.100 µs | -1.9% ✅ |

### Functions

| Benchmark | Base | PR | Change |
|-----------|------|-----|--------|
| `decode_to_vec_binary` | 1.608 ms | 1.578 ms | -1.9% ✅ |
| `decode_to_vec_mixed_50_50` | 1.284 ms | 1.260 ms | -1.9% ✅ |
| `decode_to_vec_unescaped` | 736.500 µs | 716.000 µs | -2.8% ✅ |
| `encode_to_string_binary` | 1.564 ms | 1.535 ms | -1.9% ✅ |
| `encode_to_string_mixed_50_50` | 1.269 ms | 1.255 ms | -1.1% ✅ |
| `encode_to_string_unescaped` | 958.500 µs | 949.600 µs | -0.9% ✅ |
| `encode_to_vec_binary` | 1.311 ms | 1.333 ms | +1.7% |
| `encode_to_vec_mixed_50_50` | 1.429 ms | 1.412 ms | -1.2% ✅ |
| `encode_to_vec_unescaped` | 957.100 µs | 941.700 µs | -1.6% ✅ |
| `requires_escape_all_bytes` | 423.400 µs | 417.300 µs | -1.4% ✅ |

### Iter

| Benchmark | Base | PR | Change |
|-----------|------|-----|--------|
| `decode_iter_binary` | 3.163 ms | 3.150 ms | -0.4% |
| `decode_iter_mixed_10_90` | 2.968 ms | 2.953 ms | -0.5% ✅ |
| `decode_iter_mixed_50_50` | 2.211 ms | 2.201 ms | -0.5% |
| `decode_iter_mixed_90_10` | 1.455 ms | 1.449 ms | -0.4% |
| `decode_iter_ticks` | 1.580 ms | 1.579 ms | -0.1% |
| `decode_iter_unescaped` | 1.268 ms | 1.261 ms | -0.6% ✅ |
| `encode_iter_binary` | 1.896 ms | 1.883 ms | -0.7% ✅ |
| `encode_iter_mixed_10_90` | 1.820 ms | 1.814 ms | -0.3% |
| `encode_iter_mixed_50_50` | 1.572 ms | 1.564 ms | -0.5% ✅ |
| `encode_iter_mixed_90_10` | 817.500 µs | 821.100 µs | +0.4% |
| `encode_iter_ticks` | 629.700 µs | 640.500 µs | +1.7% |
| `encode_iter_unescaped` | 629.900 µs | 633.800 µs | +0.6% |