### PR TITLE
Update `decode` to reduce reallocations without over-allocating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,11 @@ pub fn decode(input: &[u8]) -> Result<Cow<'_, [u8]>, DecodeError> {
             // We know everything up to `index` does not need to be unescaped
             let validated = &input[..index];
 
-            let mut output = Vec::with_capacity(validated.len() + 1);
+            // Start by copying the validated input as-is. For the capacity,
+            // we use a formula that gives the minimum length of the output
+            // (i.e. assuming every remaining byte is escaped)
+            let output_est_capacity = validated.len() + (input.len() - validated.len() + 2) / 3;
+            let mut output = Vec::with_capacity(output_est_capacity);
             output.extend_from_slice(validated);
 
             // Decode the remainder of the input


### PR DESCRIPTION
This sprouted from the conversation around #18

This PR tweaks the `decode` function in the case where we actually have to decode some bytes. Compared to #18, I went with the most conservative option when pre-allocating the output `Vec` for decoding: we reserve enough space based on the _minimum_ output length.

This is more based on a gut feeling, but I prefer this over allocating based on a heuristic on the assumed / max length or something (although I could definitely be persuaded if there are real-world performance numbers that benefit from tweaking how much we pre-allocate).